### PR TITLE
add comment_count property to article objects on GET and PATCH requests

### DIFF
--- a/__tests__/articles.test.js
+++ b/__tests__/articles.test.js
@@ -16,7 +16,7 @@ describe("/api/articles/:article_id", () => {
     describe("GET", () => {
         test("Status 200 - returns an article object", () => {
             return request(app)
-            .get('/api/articles/2')
+            .get('/api/articles/1')
             .expect(200)
             .then(({body}) => {
                 const article = body.article;
@@ -26,7 +26,9 @@ describe("/api/articles/:article_id", () => {
                 expect(article).toHaveProperty('author');
                 expect(article).toHaveProperty('title');
                 expect(article).toHaveProperty('article_id');
-                expect(article.article_id).toBe(2);
+                expect(article.article_id).toBe(1);
+                expect(article).toHaveProperty('comment_count');
+                expect(article.comment_count).toBe(11);
                 expect(article).toHaveProperty('body');
                 expect(article).toHaveProperty('topic');
                 expect(article).toHaveProperty('created_at');
@@ -67,6 +69,8 @@ describe("/api/articles/:article_id", () => {
                 expect(typeof article).toBe("object");
                 expect(article).toHaveProperty('article_id');
                 expect(article.article_id).toBe(3);
+                expect(article).toHaveProperty('comment_count');
+                expect(article.comment_count).toBe(2);
                 expect(article).toHaveProperty('votes');
                 expect(article.votes).toBe(5);
                 expect(article).toHaveProperty('author');

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -7,12 +7,16 @@ exports.selectArticleById = async (targetArticleId) => {
     if(!Number.isInteger(Number(targetArticleId))){
         return Promise.reject({status: 400, msg:'Bad request!'})
     } else{
-        const insertQuery = 'SELECT * FROM articles WHERE article_id = $1;'
-        const {rows: article} = await db.query(insertQuery,[targetArticleId]);
+        const articleQuery = 'SELECT * FROM articles WHERE article_id = $1;'
+        const {rows: article} = await db.query(articleQuery,[targetArticleId]);
+        const commentQuery = 'SELECT * FROM comments WHERE article_id = $1;'
+        const {rows: comments} = await db.query(commentQuery,[targetArticleId]);
         if(article.length === 0){
             return Promise.reject({status:404, msg:'Article not found!'});
+        } else {
+            article[0].comment_count = comments.length;
+            return article;
         }
-        return article;
     }
 }
 
@@ -27,11 +31,15 @@ exports.updateArticleVotesById = async (targetArticleId, incomingVotes) => {
     } else {
         const updateQuery = format('UPDATE articles SET votes = votes + %s WHERE article_id = %s returning *;',newVotes,targetArticleId);
         const {rows: article} = await db.query(updateQuery);
+        const commentQuery = 'SELECT * FROM comments WHERE article_id = $1;'
+        const {rows: comments} = await db.query(commentQuery,[targetArticleId]);
 
         if(article.length === 0){
             return Promise.reject({status:404, msg:'Article not found!'});
+        } else {
+            article[0].comment_count = comments.length;
+            return article;
         }
-        return article;
     }
 
 }


### PR DESCRIPTION
An article response object should also now include:

-comment_count which is the total count of all the comments with this article_id.

Added to GET and PATCH request endpoints.