### PR TITLE
Core 11 get/api/articles+queries

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -88,6 +88,7 @@ describe("/api/articles", () => {
                 votes: 0,
                 comment_count: '0'
               }))
+            expect(body.articles.length).not.toBe(0);
             body.articles.forEach(article => {expect(article).
               toEqual(expect.objectContaining({
                 article_id: expect.any(Number),
@@ -120,6 +121,7 @@ describe("/api/articles", () => {
               votes: 0,
               comment_count: '1'
             }))
+          expect(body.articles.length).not.toBe(0);
           body.articles.forEach(article => {expect(article).
             toEqual(expect.objectContaining({
               article_id: expect.any(Number),
@@ -152,6 +154,7 @@ describe("/api/articles", () => {
               votes: 100,
               comment_count: '11'
             }))
+          expect(body.articles.length).not.toBe(0);
           body.articles.forEach(article => {expect(article).
             toEqual(expect.objectContaining({
               article_id: expect.any(Number),
@@ -193,7 +196,7 @@ describe("/api/articles", () => {
     })
     test('Status 400 - filter by a topic that does not exist', () => {
       return request(app)
-      .get('/api/articles?sort_by=DAVE&order=desc&topic=VERISIMILITUDE')
+      .get('/api/articles?sort_by=title&order=desc&topic=VERISIMILITUDE')
       .expect(400)
       .then(({body}) => {
         expect(body.msg).toBe('Bad request!');

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -13,7 +13,6 @@ beforeEach(() => {
 });
 
 //TOPICS
-
 describe("/api/topics", () => {
   describe("GET", () => {
       test("Status 200 - Returns array of topic objects", () => {
@@ -38,7 +37,7 @@ describe("/api/topics", () => {
 //ARTICLES
 describe("/api/articles", () => {
   describe("GET", () => {
-      test("Status 200 - Returns array of article objects", () => {
+      test("Status 200 - Returns array of article objects sorted by date by default", () => {
           return request(app)
           .get('/api/articles')
           .expect(200)
@@ -70,6 +69,136 @@ describe("/api/articles", () => {
               )})
           })
       })
+      test("Status 200 - Returns array of article objects sorted by article_id", () => {
+        return request(app)
+        .get('/api/articles?sort_by=article_id')
+        .expect(200)
+        .then(({body}) => {
+            expect(body).toBeInstanceOf(Object);
+            expect(body).toHaveProperty('articles');
+            expect(body.articles).toBeSortedBy('article_id', {descending: true});
+            const firstArticle = body.articles[0];
+            expect(firstArticle).toEqual(
+              expect.objectContaining({
+                article_id: 12,
+                title: 'Moustache',
+                author: 'butter_bridge',
+                created_at: '2020-10-11T11:24:00.000Z',
+                topic: 'mitch',
+                votes: 0,
+                comment_count: '0'
+              }))
+            body.articles.forEach(article => {expect(article).
+              toEqual(expect.objectContaining({
+                article_id: expect.any(Number),
+                title: expect.any(String),
+                author: expect.any(String),
+                created_at: expect.any(String),
+                topic: expect.any(String),
+                votes: expect.any(Number),
+                comment_count: expect.any(String)
+              })
+            )})
+        })
+    })
+    test("Status 200 - Returns array of article objects sorted by title in ascending order", () => {
+      return request(app)
+      .get('/api/articles?sort_by=title&order=asc')
+      .expect(200)
+      .then(({body}) => {
+          expect(body).toBeInstanceOf(Object);
+          expect(body).toHaveProperty('articles');
+          expect(body.articles).toBeSortedBy('title', {descending: false});
+          const firstArticle = body.articles[0];
+          expect(firstArticle).toEqual(
+            expect.objectContaining({
+              article_id: 6,
+              title: 'A',
+              author: 'icellusedkars',
+              created_at: '2020-10-18T01:00:00.000Z',
+              topic: 'mitch',
+              votes: 0,
+              comment_count: '1'
+            }))
+          body.articles.forEach(article => {expect(article).
+            toEqual(expect.objectContaining({
+              article_id: expect.any(Number),
+              title: expect.any(String),
+              author: expect.any(String),
+              created_at: expect.any(String),
+              topic: expect.any(String),
+              votes: expect.any(Number),
+              comment_count: expect.any(String)
+            })
+          )})
+      })
+    })
+    test("Status 200 - Returns array of article objects sorted by votes in descending order filtered by topic 'mitch'", () => {
+      return request(app)
+      .get('/api/articles?sort_by=votes&order=desc&topic=mitch')
+      .expect(200)
+      .then(({body}) => {
+          expect(body).toBeInstanceOf(Object);
+          expect(body).toHaveProperty('articles');
+          expect(body.articles).toBeSortedBy('votes', {descending: true});
+          const firstArticle = body.articles[0];
+          expect(firstArticle).toEqual(
+            expect.objectContaining({
+              article_id: 1,
+              title: 'Living in the shadow of a great man',
+              author: 'butter_bridge',
+              created_at: '2020-07-09T20:11:00.000Z',
+              topic: 'mitch',
+              votes: 100,
+              comment_count: '11'
+            }))
+          body.articles.forEach(article => {expect(article).
+            toEqual(expect.objectContaining({
+              article_id: expect.any(Number),
+              title: expect.any(String),
+              author: expect.any(String),
+              created_at: expect.any(String),
+              topic: 'mitch',
+              votes: expect.any(Number),
+              comment_count: expect.any(String)
+            })
+          )})
+      })
+    })
+    test('Status 200 - filter by a topic that exists but has no associated articles', () => {
+      return request(app)
+      .get('/api/articles?sort_by=title&order=desc&topic=paper')
+      .expect(200)
+      .then(({body}) => {
+        expect(body).toBeInstanceOf(Object);
+            expect(body).toHaveProperty('articles');
+            expect(body.articles.length).toBe(0); 
+      })
+    })
+    test('Status 400 - sort_by a column that does not exist', () => {
+      return request(app)
+      .get('/api/articles?sort_by=DAVE&order=desc&topic=mitch')
+      .expect(400)
+      .then(({body}) => {
+        expect(body.msg).toBe('Bad request!');
+      })
+    })
+    test('Status 400 - request an order that does not exist', () => {
+      return request(app)
+      .get('/api/articles?sort_by=title&order=BANANA&topic=mitch')
+      .expect(400)
+      .then(({body}) => {
+        expect(body.msg).toBe('Bad request!');
+      })
+    })
+    test('Status 400 - filter by a topic that does not exist', () => {
+      return request(app)
+      .get('/api/articles?sort_by=DAVE&order=desc&topic=VERISIMILITUDE')
+      .expect(400)
+      .then(({body}) => {
+        expect(body.msg).toBe('Bad request!');
+      })
+    })
   })
 })
 

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -5,7 +5,10 @@ const { selectArticleById,
         addCommentByArticleId} = require("../models/articles.model")
 
 exports.getArticles = (req, res, next) => {
-    selectArticles().then((articlesData) => {
+    const sortBy = req.query.sort_by;
+    const orderBy = req.query.order;
+    const topic = req.query.topic;
+    selectArticles(sortBy, orderBy, topic).then((articlesData) => {
         res.status(200).send({articles: articlesData});
     })
     .catch(next);

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -43,7 +43,6 @@ exports.selectArticles = async (sortBy = 'created_at' ,orderBy = 'desc', in_topi
     ORDER BY ${lowerSortBy} ${upperOrderBy};`;
     const {rows} = await db.query(insertQuery);
     return rows;
-    
 }
 
 exports.selectArticleById = async (targetArticleId) => {


### PR DESCRIPTION
FEATURE REQUEST
The end point now accepts the following queries:

sort_by, which sorts the articles by any valid column (defaults to date)
order, which can be set to asc or desc for ascending or descending (defaults to descending)
topic, which filters the articles by the topic value specified in the query

Errors handled:

sort by a column that does not exist
request an invalid ordering
filter by a topic that does not exist